### PR TITLE
feat: enables formats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
             "version": "0.0.0-semantically-released",
             "license": "MIT",
             "dependencies": {
-                "ajv": "^8.12.0"
+                "ajv": "^8.12.0",
+                "ajv-formats": "^2.1.1"
             },
             "devDependencies": {
                 "@babel/core": "^7.22.8",
@@ -4472,7 +4473,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-            "dev": true,
             "dependencies": {
                 "ajv": "^8.0.0"
             },
@@ -17118,7 +17118,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-            "dev": true,
             "requires": {
                 "ajv": "^8.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
         "test": "jest"
     },
     "dependencies": {
-        "ajv": "^8.12.0"
+        "ajv": "^8.12.0",
+        "ajv-formats": "^2.1.1"
     },
     "devDependencies": {
         "@babel/core": "^7.22.8",

--- a/src/activities/ValidateJsonSchema.ts
+++ b/src/activities/ValidateJsonSchema.ts
@@ -1,5 +1,6 @@
 import type { IActivityHandler } from "@vertigis/workflow";
 import Ajv from "ajv";
+import addFormats from "ajv-formats"
 
 interface ValidateJsonSchemaInputs {
     /**
@@ -56,9 +57,10 @@ export default class ValidateJsonSchema implements IActivityHandler {
         }
 
         const ajv = new Ajv();
+        addFormats(ajv)
         const validate = ajv.compile(schema);
         const isValid = validate(data);
-        
+
         return {
             isValid,
             errors: validate.errors ? validate.errors: undefined,

--- a/src/activities/__tests__/ValidateJsonSchema.test.ts
+++ b/src/activities/__tests__/ValidateJsonSchema.test.ts
@@ -53,4 +53,108 @@ describe("ValidateJsonSchema", () => {
             "schema is required"
         );
     });
+
+    describe("formats", () => {
+        const cases = [
+            {
+                description: "a valid e-mail address",
+                input: { data: "joe.bloggs@example.com", schema: { type: "string", format: "email" } },
+                expected: true
+            },
+            {
+                description: "an invalid e-mail address",
+                input: { data: "2962", schema: { type: "string", format: "email" } },
+                expected: false
+            },
+
+            {
+                description: "valid regex",
+                input: { data: "[0-9]", schema: { type: "string", format: "regex" } },
+                expected: true
+            },
+            {
+                description: "invalid regex",
+                input: { data: "[9-0]", schema: { type: "string", format: "regex" } },
+                expected: false
+            },
+            {
+                description: "not string is valid",
+                input: { data: 123, schema: { type: "number", format: "regex" } },
+                expected: true
+            },
+
+            {
+                description: "valid uri",
+                input: { data: "urn:isbn:978-3-531-18621-4", schema: { type: "string", format: "uri" } },
+                expected: true
+            },
+            {
+                description: "invalid relative uri-reference",
+                input: { data: "/abc", schema: { type: "string", format: "uri" } },
+                expected: false
+            },
+
+            {
+                description: "valid uri-template",
+                input: {
+                    data: "http://example.com/dictionary/{term:1}/{term}",
+                    schema: { type: "string", format: "uri-template" }
+                },
+                expected: true
+            },
+            {
+                description: "invalid uri-template",
+                input: {
+                    data: "http://example.com/dictionary/{term:1}/{term",
+                    schema: { type: "string", format: "uri-template" }
+                },
+                expected: false
+            },
+
+            {
+                description: "valid hostname",
+                input: { data: "123.example.com", schema: { type: "string", format: "hostname" } },
+                expected: true
+            },
+
+            {
+                description: "a valid date string",
+                input: { data: "1963-06-19", schema: { type: "string", format: "date" } },
+                expected: true
+            },
+            {
+                description: "an invalid date string",
+                input: { data: "06/19/1963", schema: { type: "string", format: "date" } },
+                expected: false
+            },
+
+            {
+                description: "a valid uuid",
+                input: { data: "f81d4fae-7dec-11d0-a765-00a0c91e6bf6", schema: { type: "string", format: "uuid" } },
+                expected: true
+            },
+            {
+                description: "not valid uuid",
+                input: { data: "f81d4fae7dec11d0a76500a0c91e6bf6", schema: { type: "string", format: "uuid" } },
+                expected: false
+            }
+        ];
+
+
+        it.each(cases)("$description", ({ input, expected }) => {
+            const activity: ValidateJsonSchema = new ValidateJsonSchema();
+            const { isValid, errors } = activity.execute(input);
+
+            expect(typeof isValid).toBe("boolean");
+
+            if (expected) {
+                expect(isValid).toBe(true);
+                expect(errors).toBeUndefined();
+            } else {
+                expect(isValid).toBe(false);
+                expect(errors).toBeDefined();
+                expect(Array.isArray(errors)).toBe(true);
+            }
+        });
+    });
 });


### PR DESCRIPTION
allows to use the [ajv-formats](https://github.com/ajv-validator/ajv-formats) like `email` or `date`